### PR TITLE
keepalive proxy connection

### DIFF
--- a/nginx/doh
+++ b/nginx/doh
@@ -37,7 +37,9 @@ server {
   
   location = /dns-query {
     proxy_set_header Host $http_host;
+    proxy_set_header Connection "";
     proxy_set_header X-Forwarded-For 127.0.0.1;
+    proxy_http_version 1.1;
     proxy_redirect off;
     proxy_buffering off;
     proxy_pass http://dohproxy_backend;


### PR DESCRIPTION
https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version
https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
TL;DR:
`For HTTP, the proxy_http_version directive should be set to “1.1” and the “Connection” header field should be cleared`