### PR TITLE
Update turris-omnia-DE.md

### DIFF
--- a/howtos/other/turris-omnia-DE.md
+++ b/howtos/other/turris-omnia-DE.md
@@ -8,7 +8,8 @@ Diese Konfigurationsvorschläge richten sich an sehr erfahrene Personen. Es muss
 Der Turris Omnia Router kann per SSH ebenfalls auf DoT konfiguriert werden. Die Anleitung sollte auch allgemein für OpenWRT basierte Geräte funktionieren.
 
 0. Der Turris Omnia Router kann per SSH ebenfalls auf DoT konfiguriert werden. Die Anleitung sollte auch allgemein für OpenWRT basierte Geräte funktionieren.
-   ```
+   Dazu die folgenden Eintraege in der (neuen) Datei '/etc/resolver/dns_servers/99_digiges.conf' erfassen - die Datei wird bei einem turris update nicht überschrieben!
+      ```
    name="99_digiges.conf"
    description="Digitale Gesellschaft (TLS)"
    enable_tls="1"
@@ -17,10 +18,18 @@ Der Turris Omnia Router kann per SSH ebenfalls auf DoT konfiguriert werden. Die 
    ipv6="2a05:fc84::42"
    hostname="dns.digitale-gesellschaft.ch"
    ```
-0. Lokalen Resolver umstellen. In der Datei /etc/config/resolver in der Sektion config resolver ‘common‘ folgende Zeilen ändern/hinzufügen: 
+0. Lokalen Resolver umstellen. In der Datei /etc/config/resolver in der Sektion config resolver ‘common‘ folgende Zeilen ändern/hinzufügen:
+   Der folgende Block verhindert die automatische Sicherung der Konfigurationeinstellungen, bitte vermeiden! 
    ```
    option forward_upstream ‚1'
    option forward_custom ’99_digiges'
+   ```
+
+   Der folgende Block ermöglicht die automatische Sicherung der Konfigurationeinstellungen!
+   ```
+   uci set resolver.common.forward_upstream='1'
+   uci set resolver.common.forward_custom='99_digiges'
+   uci commit
    ```
 0. Lokalen Resolver neustarten
    ```


### PR DESCRIPTION
Leider funktioniert das mit turris os 5.0.4 so nicht. 
Deshalb schlage ich zunächst die Änderungen und Ergänzungen /1 und /2 vor:
/1 Datei /etc/resolver/dns_servers/99_digiges.conf anlegen und füllen
/2 Konfiguration des resolvers mithilfe von UCI Transaktionen um alle Konfigurationsänderungen auch in der Sicherung der Konfiguration mitzuziehen

Ausserdem muss die Konfiguration von kresd/dnsmasq/odhcpd/etc überarbeitet werden, um Probleme bei der Konfiguration von KRESD zu lösen:
```
root@turris:/etc# /etc/init.d/resolver restart
+Called /etc/init.d/kresd stop
set dhcp script
Error! 99_digiges does not contain variables for DNS over TLS!
Called /etc/init.d/kresd start
set dhcp script
Called /etc/resolver/dhcp_host_domain_ng.py
```