### PR TITLE
Support Stubby 0.2.5

### DIFF
--- a/howtos/other/stubby-DE.md
+++ b/howtos/other/stubby-DE.md
@@ -14,6 +14,10 @@ In Konfigurationsdatei /etc/stubby/stubby.yml hinzufügen um DoT im Strict-Mode 
     dns_transport_list:
       - GETDNS_TRANSPORT_TLS
     
+    listen_addresses:
+      - 127.0.0.1
+      -  0::1
+    
     tls_authentication: GETDNS_AUTHENTICATION_REQUIRED
     
     round_robin_upstreams: 1


### PR DESCRIPTION
Stubby 0.2.5 requires the definition of the `listen_addresses`. If I run the provided sample configuration on debian 10, stubby fails with the following error:
> Could not parse config file "/etc/stubby/stubby.yml": A helper function for dicts had a name argument that for a name that is not in the dict. 

With the `listen_addresses` set to the loopback addresses, it works as expected. I would suggest to add the entry just in case someone tries to use an older version of stubby.