### PR TITLE
Enable TLS 0-RTT zero round trip time TLS 1.3 early data

### DIFF
--- a/configuration-files/nginx/nginx.conf
+++ b/configuration-files/nginx/nginx.conf
@@ -46,6 +46,8 @@ http {
 	##
 
 	ssl_session_cache shared:ssl_session_cache:1M;
+        # Enables TLS 1.3 early data.
+        ssl_early_data on;
 
 	##
 	# Gzip Settings


### PR DESCRIPTION
Since default is disabled, consider enabling. In hope of faster DNS latency by eliminating TLS handshaking delays.

docs:
https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_early_data