### PR TITLE
Add ca_file parameter for Turris Omnia configuration

### DIFF
--- a/howtos/other/turris-omnia-DE.md
+++ b/howtos/other/turris-omnia-DE.md
@@ -16,6 +16,7 @@ Der DNS-Resolver des Turris Omnia Router, kresd, kann per SSH auch für DoT konf
    port="853"
    ipv4="185.95.218.42 185.95.218.43"
    ipv6="2a05:fc84::42 2a05:fc84::43"
+   ca_file="/etc/ssl/certs/ca-certificates.crt"
    hostname="dns.digitale-gesellschaft.ch"
    ```
 2. Lokalen Resolver umstellen.


### PR DESCRIPTION
Taken from the default `99_cloudflare .conf` configuration. Seems like this fixes the issue of actually requesting via DoT (and removes all warnings upon restarting the resolver).