### PR TITLE
Remove ssl_trusted_certificate directive from nginx config

### DIFF
--- a/configuration-files/roles/web_server/templates/res-https.conf.j2
+++ b/configuration-files/roles/web_server/templates/res-https.conf.j2
@@ -7,9 +7,6 @@ server {
   ssl_certificate {{ cert_path }}live/{{ name_intern }}.{{ domain }}.ecdsa/fullchain.pem;
   ssl_certificate_key {{ cert_path }}live/{{ name_intern }}.{{ domain }}.ecdsa/privkey.pem;
 
-  # ssl_stapling is globaly configured in tls.conf
-  ssl_trusted_certificate {{ cert_path }}live/{{ name_intern }}.{{ domain }}.ecdsa/chain.pem;
-
   add_header Strict-Transport-Security max-age=15768000;
 	
   # restrict HTTP verbs to only GET, POST and HEAD


### PR DESCRIPTION
Let's Encrypt has ended support for OCSP stapling:

* https://letsencrypt.org/2022/09/07/new-life-for-crls
* https://letsencrypt.org/2024/07/23/replacing-ocsp-with-crls
* https://letsencrypt.org/2024/12/05/ending-ocsp