### PR TITLE
Fix ipv6 node addresses (local deployment)

### DIFF
--- a/configuration-files/host_vars/localdns1.yml
+++ b/configuration-files/host_vars/localdns1.yml
@@ -3,9 +3,9 @@ name_public: localdns1
 name_intern: localres1
 name_other_public: localdns2
 name_other_intern: localres2
-ip4: "10.52.7.116"
-ip6: "fd42:56b6:246b:67bc:58e8:cad7:b33:116"
-ip4_other: "10.52.7.117"
-ip6_other: "fd42:56b6:246b:67bc:58e8:cad7:b33:117"
+ip4: "{{ ip4_dns1 }}"
+ip6: "{{ ip6_dns1 }}"
+ip4_other: "{{ ip4_dns2 }}"
+ip6_other: "{{ ip6_dns2 }}"
 vrrp_prio_42: 200
 vrrp_prio_43: 100

--- a/configuration-files/host_vars/localdns2.yml
+++ b/configuration-files/host_vars/localdns2.yml
@@ -3,9 +3,9 @@ name_public: localdns2
 name_intern: localres2
 name_other_public: localdns1
 name_other_intern: localres1
-ip4: "10.52.7.117"
-ip6: "fd42:56b6:246b:67bc:58e8:cad7:b33:117"
-ip4_other: "10.52.7.116"
-ip6_other: "fd42:56b6:246b:67bc:58e8:cad7:b33:116"
+ip4: "{{ ip4_dns2 }}"
+ip6: "{{ ip6_dns2 }}"
+ip4_other: "{{ ip4_dns1 }}"
+ip6_other: "{{ ip6_dns1 }}"
 vrrp_prio_42: 100
 vrrp_prio_43: 200

--- a/configuration-files/scripts/local-lxc-setup.sh
+++ b/configuration-files/scripts/local-lxc-setup.sh
@@ -4,8 +4,8 @@ readonly container1Name="localdns1"
 readonly container2Name="localdns2"
 readonly container1IpV4="10.52.7.116"
 readonly container2IpV4="10.52.7.117"
-readonly container1IpV6="fd42:56b6:246b:67bc:58e8:cad7:b33:116"
-readonly container2IpV6="fd42:56b6:246b:67bc:58e8:cad7:b33:117"
+readonly container1IpV6="fd42:56b6:246b:67bc::116"
+readonly container2IpV6="fd42:56b6:246b:67bc::117"
 
 readonly containerOs="ubuntu:22.04"
 


### PR DESCRIPTION
It looks like `nginx` is trying to bind to a non-existent ipv6 in local deployment:

```
Nov 02 15:14:12 localdns1 systemd[1]: Starting A high performance web server and a reverse proxy server...
Nov 02 15:14:12 localdns1 nginx[17898]: nginx: [emerg] bind() to [fd42:56b6:246b:67bc:58e8:cad7:b33:116]:31080 failed (99: Unknown error)
Nov 02 15:14:12 localdns1 nginx[17898]: nginx: configuration file /etc/nginx/nginx.conf test failed
```