### PR TITLE
Ubuntu noble ssh server fixes

### DIFF
--- a/configuration-files/roles/base/handlers/main.yml
+++ b/configuration-files/roles/base/handlers/main.yml
@@ -1,7 +1,14 @@
 ---
-- name: restart sshd
+- name: restart ssh.socket
+  when: ssh_socket_is_active.rc == 0
+  systemd_service:
+    name: ssh.socket
+    state: restarted
+    daemon_reload: true
+
+- name: restart ssh
   service:
-    name: sshd
+    name: ssh
     state: restarted
 
 - name: persist rules

--- a/configuration-files/roles/base/tasks/sshd.yml
+++ b/configuration-files/roles/base/tasks/sshd.yml
@@ -1,4 +1,40 @@
 ---
+# The result of this call is used to suppress the ssh.socket handler on older
+# ubuntu releases where the socket unit is not present. Note that the drop-in
+# is installed regardless of the result here. This is done to ensure ssh will
+# start on the correct port after a dist-upgrade.
+- name: ssh | check if systemd ssh.socket unit is active
+  changed_when: false
+  failed_when: false
+  register: ssh_socket_is_active
+  command:
+    argv:
+      - /usr/bin/systemctl
+      - is-active
+      - ssh.socket
+
+- name: ssh | systemd ssh.socket unit drop-in directory present
+  file:
+    state: directory
+    path: /etc/systemd/system/ssh.socket.d
+    owner: root
+    group: root
+    mode: 0755
+
+- name: ssh | systemd ssh.socket unit drop-in present
+  notify:
+    - restart ssh.socket
+  copy:
+    content: |
+      [Socket]
+      ListenStream=
+      ListenStream=0.0.0.0:{{ network_port_ssh }}
+      ListenStream=[::]:{{ network_port_ssh }}
+    dest: /etc/systemd/system/ssh.socket.d/50-port.conf
+    owner: root
+    group: root
+    mode: 0644
+
 - name: ssh | configure sshd
   lineinfile:
     path: "/etc/ssh/sshd_config"
@@ -18,4 +54,4 @@
     - { key: "Port", value: "{{ network_port_ssh }}" } # use custom listening port
     - { key: "X11Forwarding", value: "no" } # disable unused X11 forwarding, console access only
   notify:
-    - restart sshd
+    - restart ssh

--- a/configuration-files/scripts/local-lxc-setup.sh
+++ b/configuration-files/scripts/local-lxc-setup.sh
@@ -34,7 +34,7 @@ init_container() {
 
     echo "Temporarily allow SSH password authentication"
     sudo lxc exec "$1" -- sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config > /dev/null
-    sudo lxc exec "$1" -- systemctl restart sshd > /dev/null
+    sudo lxc exec "$1" -- systemctl restart ssh > /dev/null
 
     echo "Copy public SSH key (~/.ssh/id_rsa) to container '$1'"
     ssh-copy-id -p 22 -i ~/.ssh/id_rsa "$4@$1" > /dev/null
@@ -42,7 +42,7 @@ init_container() {
     echo "Disable SSH password authentication"
     sudo lxc exec "$1" -- sed -i 's/PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config > /dev/null
     sudo lxc exec "$1" -- sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/' /etc/ssh/sshd_config > /dev/null
-    sudo lxc exec "$1" -- systemctl restart sshd > /dev/null
+    sudo lxc exec "$1" -- systemctl restart ssh > /dev/null
 }
 
 start_container() {


### PR DESCRIPTION
* Systems newly installed with Ubuntu noble use systemd socket activation to activate the ssh server. A drop-in is requried to support custom ssh ports.
* Ubuntu noble dropped the sshd.service unit alias. It is safe to just use ssh.service also on jammy.