### PR TITLE
Disable IPv6 duplicate address detection

### DIFF
--- a/configuration-files/roles/base/tasks/network.yml
+++ b/configuration-files/roles/base/tasks/network.yml
@@ -1,4 +1,17 @@
 ---
+- name: Disable IPv6 duplicate address detection
+  loop:
+    - all
+    - default
+    - "{{ if_primary }}"
+  sysctl:
+    name: "net.ipv6.conf.{{ item }}.accept_dad"
+    value: '0'
+    sysctl_set: true
+    sysctl_file: /etc/sysctl.d/99-disable-dad-ipv6.conf
+    state: present
+    reload: true
+
 - name: Generate network config file from template
   template:
     src: 00-installer-config.yaml.j2


### PR DESCRIPTION
IPv6 dad can lead to nasty race conditions in ci (and probably also on real system boots).