### PR TITLE
Generate unbound remote key if necessary

### DIFF
--- a/configuration-files/roles/dns_backend/tasks/unbound.yml
+++ b/configuration-files/roles/dns_backend/tasks/unbound.yml
@@ -17,6 +17,12 @@
     name: unbound
     state: started
 
+- name: unbound | control key present
+  command:
+    argv:
+      - /usr/sbin/unbound-control-setup
+    creates: /etc/unbound/unbound_server.pem
+
 - name: unbound | generate config file from template
   template:
     src: unbound.conf.j2


### PR DESCRIPTION
Excerpt from /usr/share/doc/unbound/NEWS.Debian.gz:

    unbound (1.15.0-5) unstable; urgency=medium

      With this version we switched from the control interface on localhost
      port 8953 to a unix-domain socket /run/unbound.ctl. This interface
      does not use the keys/certificates (/etc/unbound/unbound_control.key,
      /etc/unbound/unbound_server.pem etc) which are set up by the
      unbound-control-setup utility.

      This change is done in the new config file fragment,
      /etc/unbound/unbound.conf.d/remote-control.conf

     -- Michael Tokarev <mjt@tls.msk.ru>  Thu, 28 Apr 2022 11:27:58 +0300