### PR TITLE
Remove flags doTCP and exactPathMatching from dnsdist listeners

### DIFF
--- a/configuration-files/roles/dns_frontend/templates/dnsdist.conf.j2
+++ b/configuration-files/roles/dns_frontend/templates/dnsdist.conf.j2
@@ -79,7 +79,7 @@ getPool(""):setCache(pc)
 addTLSLocal( "{{ interf }}",
              { "{{ cert_path }}live/{{ host_public }}.{{ domain }}.ecdsa/fullchain.pem", "{{ cert_path }}live/{{ host_public }}.{{ domain }}.rsa/fullchain.pem" },
              { "{{ cert_path }}live/{{ host_public }}.{{ domain }}.ecdsa/privkey.pem",   "{{ cert_path }}live/{{ host_public }}.{{ domain }}.rsa/privkey.pem"   },
-             { doTCP = true, exactPathMatching = true, minTLSVersion = "tls1.2", preferServerCiphers = true, reusePort = true, tcpFastOpenQueueSize = 50 }
+             { minTLSVersion = "tls1.2", preferServerCiphers = true, reusePort = true, tcpFastOpenQueueSize = 50 }
            )
 {% endfor %}
 {% endfor %}
@@ -91,7 +91,7 @@ addDOHLocal( "{{ interf }}",
              { "{{ cert_path }}live/{{ host_public }}.{{ domain }}.ecdsa/fullchain.pem", "{{ cert_path }}live/{{ host_public }}.{{ domain }}.rsa/fullchain.pem" },
              { "{{ cert_path }}live/{{ host_public }}.{{ domain }}.ecdsa/privkey.pem",   "{{ cert_path }}live/{{ host_public }}.{{ domain }}.rsa/privkey.pem"   },
              { "/", "/dns-query" },
-             { doTCP = true, exactPathMatching = true, minTLSVersion = "tls1.2", preferServerCiphers = true, reusePort = true, tcpFastOpenQueueSize = 50 }
+             { minTLSVersion = "tls1.2", preferServerCiphers = true, reusePort = true, tcpFastOpenQueueSize = 50 }
            )
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
* The doTCP flag isn't expected neither on addTLSLocal nor on addDOHLocal. It used to be there on addLocal but was removed in 1.4.0. https://www.dnsdist.org/reference/config.html?highlight=dotcp#addLocal
* The exactPathMatching flag only exists on addDOHLocal and not on addTLSLocal. It has been introduced in 1.6.0 to allow reverting a behavior change introduced in 1.5.0. No need to specify the default explicitly. https://www.dnsdist.org/reference/config.html?highlight=exactPathMatching#addDOHLocal

Removal of those flags reduces log noise in noble. It doesn't change behavior in jammy.