### PR TITLE
Feature: Enable DoQ and DoH3 for frontend

### DIFF
--- a/configuration-files/roles/base/tasks/firewall.yml
+++ b/configuration-files/roles/base/tasks/firewall.yml
@@ -226,15 +226,15 @@
   iptables:
     ip_version: "{{ item.version }}"
     chain: INPUT
-    protocol: "{{ item.protocol }}"
+    protocol: "{{ item.proto }}"
     destination: "{{ item.ip }}"
     destination_port: "53"
     jump: REJECT
-  loop:
-    - { version: "ipv4", protocol: "tcp", ip: "{{ ip4_vip_dns1 }}" }
-    - { version: "ipv4", protocol: "udp", ip: "{{ ip4_vip_dns2 }}" }
-    - { version: "ipv6", protocol: "tcp", ip: "{{ ip6_vip_dns1 }}" }
-    - { version: "ipv6", protocol: "udp", ip: "{{ ip6_vip_dns2 }}" }
+  vars:
+    protocols:
+      - { proto: "tcp" }
+      - { proto: "udp" }
+  loop: "{{ dns_vip_addresses | product(protocols) | map('combine') | list }}"
   notify:
     - persist rules
 

--- a/configuration-files/roles/base/tasks/firewall.yml
+++ b/configuration-files/roles/base/tasks/firewall.yml
@@ -166,86 +166,59 @@
 
 # DoT / DoH - communication between clients and the DNS resolver
 
-- name: firewall | DoH/DoT | explicitly allow DNS server to receive queries from clients on port 80/tcp, 443/tcp and 853/tcp
+- name: firewall | DoH/DoH3/DoT/DoQ | explicitly allow DNS server to receive queries from clients
   iptables:
     ip_version: "{{ item.version }}"
     chain: INPUT
-    protocol: tcp
+    protocol: "{{ item.proto }}"
     destination: "{{ item.ip }}"
-    destination_ports:
-      - "80"
-      - "443"
-      - "853"
+    destination_port: "{{ item.port }}"
     jump: ACCEPT
-  loop:
-    - { version: "ipv4", ip: "{{ ip4_vip_dns1 }}" }
-    - { version: "ipv4", ip: "{{ ip4_vip_dns2 }}" }
-    - { version: "ipv6", ip: "{{ ip6_vip_dns1 }}" }
-    - { version: "ipv6", ip: "{{ ip6_vip_dns2 }}" }
+  loop: "{{ dns_vip_addresses | product(dns_service_ports) | map('combine') | list }}"
   notify:
     - persist rules
 
-- name: firewall | DoH/DoT NOTRACK | disable connection tracking on queries from clients
+- name: firewall | DoH/DoH3/DoT/DoQ NOTRACK | disable connection tracking on queries from clients
   iptables:
     ip_version: "{{ item.version }}"
     table: raw
     chain: PREROUTING
-    protocol: tcp
+    protocol: "{{ item.proto }}"
     destination: "{{ item.ip }}"
     jump: NOTRACK
-  loop:
-    - { version: "ipv4", ip: "{{ ip4_vip_dns1 }}" }
-    - { version: "ipv4", ip: "{{ ip4_vip_dns2 }}" }
-    - { version: "ipv6", ip: "{{ ip6_vip_dns1 }}" }
-    - { version: "ipv6", ip: "{{ ip6_vip_dns2 }}" }
+  vars:
+    protocols:
+      - { proto: "tcp" }
+      - { proto: "udp" }
+  loop: "{{ dns_vip_addresses | product(protocols) | map('combine') | list }}"
   notify:
     - persist rules
 
-- name: firewall | DoH/DoT | explicitly allow DNS server to answer clients on port 80/tcp, 443/tcp and 853/tcp
+- name: firewall | DoH/DoH3/DoT/DoQ | explicitly allow DNS server to answer clients on port 80/tcp, 443/tcp_udp and 853/tcp_udp
   iptables:
     ip_version: "{{ item.version }}"
     chain: OUTPUT
-    protocol: tcp
+    protocol: "{{ item.proto }}"
     source: "{{ item.ip }}"
     source_port: "{{ item.port }}"
     jump: ACCEPT
-  loop:
-    - { version: "ipv4", ip: "{{ ip4_vip_dns1 }}", port: "80" }
-    - { version: "ipv4", ip: "{{ ip4_vip_dns2 }}", port: "80" }
-    - { version: "ipv6", ip: "{{ ip6_vip_dns1 }}", port: "80" }
-    - { version: "ipv6", ip: "{{ ip6_vip_dns2 }}", port: "80" }
-    - { version: "ipv4", ip: "{{ ip4_vip_dns1 }}", port: "443" }
-    - { version: "ipv4", ip: "{{ ip4_vip_dns2 }}", port: "443" }
-    - { version: "ipv6", ip: "{{ ip6_vip_dns1 }}", port: "443" }
-    - { version: "ipv6", ip: "{{ ip6_vip_dns2 }}", port: "443" }
-    - { version: "ipv4", ip: "{{ ip4_vip_dns1 }}", port: "853" }
-    - { version: "ipv4", ip: "{{ ip4_vip_dns2 }}", port: "853" }
-    - { version: "ipv6", ip: "{{ ip6_vip_dns1 }}", port: "853" }
-    - { version: "ipv6", ip: "{{ ip6_vip_dns2 }}", port: "853" }
+  loop: "{{ dns_vip_addresses | product(dns_service_ports) | map('combine') | list }}"
   notify:
     - persist rules
 
-- name: firewall | DoH/DoT NOTRACK | disable connection tracking on responses to clients
+- name: firewall | DoH/DoH3/DoT/DoQ NOTRACK | disable connection tracking on responses to clients
   iptables:
     ip_version: "{{ item.version }}"
     table: raw
     chain: OUTPUT
-    protocol: tcp
+    protocol: "{{ item.proto }}"
     source: "{{ item.ip }}"
     jump: NOTRACK
-  loop:
-    - { version: "ipv4", ip: "{{ ip4_vip_dns1 }}" }
-    - { version: "ipv4", ip: "{{ ip4_vip_dns2 }}" }
-    - { version: "ipv6", ip: "{{ ip6_vip_dns1 }}" }
-    - { version: "ipv6", ip: "{{ ip6_vip_dns2 }}" }
-    - { version: "ipv4", ip: "{{ ip4_vip_dns1 }}" }
-    - { version: "ipv4", ip: "{{ ip4_vip_dns2 }}" }
-    - { version: "ipv6", ip: "{{ ip6_vip_dns1 }}" }
-    - { version: "ipv6", ip: "{{ ip6_vip_dns2 }}" }
-    - { version: "ipv4", ip: "{{ ip4_vip_dns1 }}" }
-    - { version: "ipv4", ip: "{{ ip4_vip_dns2 }}" }
-    - { version: "ipv6", ip: "{{ ip6_vip_dns1 }}" }
-    - { version: "ipv6", ip: "{{ ip6_vip_dns2 }}" }
+  vars:
+    protocols:
+      - { proto: "tcp" }
+      - { proto: "udp" }
+  loop: "{{ dns_vip_addresses | product(protocols) | map('combine') | list }}"
   notify:
     - persist rules
 

--- a/configuration-files/roles/base/vars/main.yml
+++ b/configuration-files/roles/base/vars/main.yml
@@ -1,2 +1,14 @@
 ---
 network_port_ssh: 55022
+
+dns_vip_addresses:
+  - { version: "ipv4", ip: "{{ ip4_vip_dns1 }}" }
+  - { version: "ipv4", ip: "{{ ip4_vip_dns2 }}" }
+  - { version: "ipv6", ip: "{{ ip6_vip_dns1 }}" }
+  - { version: "ipv6", ip: "{{ ip6_vip_dns2 }}" }
+dns_service_ports:
+  - { proto: "tcp", port: "80" }
+  - { proto: "tcp", port: "443" }
+  - { proto: "tcp", port: "853" }
+  - { proto: "udp", port: "443" }
+  - { proto: "udp", port: "853" }

--- a/configuration-files/roles/dns_frontend/templates/dnsdist.conf.j2
+++ b/configuration-files/roles/dns_frontend/templates/dnsdist.conf.j2
@@ -84,6 +84,17 @@ addTLSLocal( "{{ interf }}",
 {% endfor %}
 {% endfor %}
 
+-- DoQ Frontend
+{% for interf in vip_interfaces %}
+{% for i in range(dnsdist_nof_thread_doq_per_ip) %}
+addDOQLocal( "{{ interf }}",
+             { "{{ cert_path }}live/{{ host_public }}.{{ domain }}.ecdsa/fullchain.pem", "{{ cert_path }}live/{{ host_public }}.{{ domain }}.rsa/fullchain.pem" },
+             { "{{ cert_path }}live/{{ host_public }}.{{ domain }}.ecdsa/privkey.pem",   "{{ cert_path }}live/{{ host_public }}.{{ domain }}.rsa/privkey.pem"   },
+             { reusePort = true }
+           )
+{% endfor %}
+{% endfor %}
+
 -- DoH Frontend
 {% for interf in vip_interfaces %}
 {% for i in range(dnsdist_nof_thread_doh_per_ip) %}
@@ -91,7 +102,7 @@ addDOHLocal( "{{ interf }}",
              { "{{ cert_path }}live/{{ host_public }}.{{ domain }}.ecdsa/fullchain.pem", "{{ cert_path }}live/{{ host_public }}.{{ domain }}.rsa/fullchain.pem" },
              { "{{ cert_path }}live/{{ host_public }}.{{ domain }}.ecdsa/privkey.pem",   "{{ cert_path }}live/{{ host_public }}.{{ domain }}.rsa/privkey.pem"   },
              { "/", "/dns-query" },
-             { minTLSVersion = "tls1.2", preferServerCiphers = true, reusePort = true, tcpFastOpenQueueSize = 50 }
+             { minTLSVersion = "tls1.2", preferServerCiphers = true, reusePort = true, tcpFastOpenQueueSize = 50, customResponseHeaders = {["alt-svc"]='h3=":443"'} }
            )
 {% endfor %}
 {% endfor %}

--- a/configuration-files/roles/dns_frontend/templates/dnsdist.conf.j2
+++ b/configuration-files/roles/dns_frontend/templates/dnsdist.conf.j2
@@ -96,6 +96,16 @@ addDOHLocal( "{{ interf }}",
 {% endfor %}
 {% endfor %}
 
+-- DoH3 Fronted
+{% for interf in vip_interfaces %}
+{% for i in range(dnsdist_nof_thread_doh3_per_ip) %}
+addDOH3Local( "{{ interf }}",
+             { "{{ cert_path }}live/{{ host_public }}.{{ domain }}.ecdsa/fullchain.pem", "{{ cert_path }}live/{{ host_public }}.{{ domain }}.rsa/fullchain.pem" },
+             { "{{ cert_path }}live/{{ host_public }}.{{ domain }}.ecdsa/privkey.pem",   "{{ cert_path }}live/{{ host_public }}.{{ domain }}.rsa/privkey.pem"   },
+             { preferServerCiphers = true, reusePort = true }
+           )
+{% endfor %}
+{% endfor %}
 
 -- ---------------------------------------------------------------------------------------------------------------------
 -- Upstream DNS resolver (unbound)

--- a/configuration-files/roles/dns_frontend/vars/main.yml
+++ b/configuration-files/roles/dns_frontend/vars/main.yml
@@ -9,5 +9,4 @@ dnsdist_nof_thread_dot_per_ip: 3
 dnsdist_nof_thread_doq_per_ip: 3
 dnsdist_nof_thread_doh_per_ip: 3
 dnsdist_nof_thread_doh3_per_ip: 3
-
 dnsdist_nof_thread_upstream: 4

--- a/configuration-files/roles/dns_frontend/vars/main.yml
+++ b/configuration-files/roles/dns_frontend/vars/main.yml
@@ -7,4 +7,6 @@ vip_interfaces:
 
 dnsdist_nof_thread_dot_per_ip: 3
 dnsdist_nof_thread_doh_per_ip: 3
+dnsdist_nof_thread_doh3_per_ip: 3
+
 dnsdist_nof_thread_upstream: 4

--- a/configuration-files/roles/dns_frontend/vars/main.yml
+++ b/configuration-files/roles/dns_frontend/vars/main.yml
@@ -6,6 +6,7 @@ vip_interfaces:
   - "{{ ip6_vip_dns2 }}"
 
 dnsdist_nof_thread_dot_per_ip: 3
+dnsdist_nof_thread_doq_per_ip: 3
 dnsdist_nof_thread_doh_per_ip: 3
 dnsdist_nof_thread_doh3_per_ip: 3
 


### PR DESCRIPTION
This PR enables DNS over HTTP3 and DNS over QUIC in the dnsdist frontend

### Questions

**DNSDist**
I configured `customResponseHeaders = {["alt-svc"]='h3=":443"'} }` in order to [encourage regular DoH clients](https://www.dnsdist.org/guides/dns-over-http3.html#advertising-dns-over-http-3-support) to use DoH3 instead. Do we want that?

### ToDo
- [ ] Discuss options enabled in dnsdist
- [ ] Add additional smoketests

Fixes #57