### PR TITLE
Switch to dnsdist 2.1

### DIFF
--- a/configuration-files/roles/dns_frontend/files/dnsdist.sources
+++ b/configuration-files/roles/dns_frontend/files/dnsdist.sources
@@ -2,5 +2,5 @@ Uris: https://repo.powerdns.com/ubuntu
 Components: main
 Types: deb
 Architectures: amd64
-Suites: noble-dnsdist-20
+Suites: noble-dnsdist-21
 Signed-By: /etc/apt/keyrings/FD380FBB-pub.asc


### PR DESCRIPTION
* https://blog.powerdns.com/2026/07/02/powerdns-dnsdist-2.1.0-released
* https://www.dnsdist.org/upgrade_guide.html#x-to-2-1-0