### PR TITLE
Mitigate CVE-2026-44690

### DIFF
--- a/configuration-files/roles/dns_backend/templates/unbound.conf.j2
+++ b/configuration-files/roles/dns_backend/templates/unbound.conf.j2
@@ -84,6 +84,9 @@ server:
   so-rcvbuf:              {{ unbound_so_rcvbuf }}
   so-sndbuf:              {{ unbound_so_sndbuf }}
 
+  # Mitigate CVE-2026-44690
+  aggressive-nsec:        no
+
 {% if unbound_test_records %}
   # --------------------------------------------------------------------------------------------------------------------
   # Test records


### PR DESCRIPTION
Add the mitigation for CVE-2026-44690 to the repository. This has been rolled out manually when the CVE became public in the hope that updated distro packages will become available soonish. That didn't happen.

Commit this change to the repo now, so its safe to deploy with config management again.